### PR TITLE
Update beamformer weights

### DIFF
--- a/dsacalib/calib.py
+++ b/dsacalib/calib.py
@@ -672,8 +672,8 @@ def calculate_bandpass(
     If `filter_phase` is set to `True`, then use savgol filter to smooth the bandpass phases,
     and channel flags are not propagated to the returned flags array.
     """
-    if not delay_bandpass_cal_prefix:
-        delay_bandpass_cal_prefix = table_prefix
+    if not delay_bandpass_table_prefix:
+        delay_bandpass_table_prefix = table_prefix
     fobs = freq_GHz_from_ms(msname)
     fmean = np.mean(fobs)
 
@@ -706,7 +706,7 @@ def combine_tables(
         msname: str, table_prefix: str, delay_bandpass_table_prefix: str = "",
         filter_phase: bool = True) -> None:
     """Combine gain, bandpass and delay tables into a single bandpass table."""
-
+    
     bandpass, flags = calculate_bandpass(
         msname, table_prefix, delay_bandpass_table_prefix, filter_phase)
 

--- a/dsacalib/calib.py
+++ b/dsacalib/calib.py
@@ -697,7 +697,7 @@ def calculate_bandpass(
 
     bandpass = (
         bacal * bpcal * gacal * gpcal *
-        np.exp(2j*np.pi * (fmean - fobs[:, np.newaxis]) * kcal))
+        np.exp(2j*np.pi * (fobs[:, np.newaxis] - fmean) * kcal))
 
     return bandpass, flags
 

--- a/dsacalib/calib.py
+++ b/dsacalib/calib.py
@@ -664,7 +664,7 @@ def calibrate_phases(
                 cb.close()
 
 
-def calculate_bandpass(
+def calculate_bandpass_from_all_tables(
         msname: str, table_prefix: str, delay_bandpass_table_prefix: str = "",
         filter_phase: bool = True) -> Tuple[np.ndarray]:
     """Combines gain, bandpass, and delay tables into a single bandpass.
@@ -707,7 +707,7 @@ def combine_tables(
         filter_phase: bool = True) -> None:
     """Combine gain, bandpass and delay tables into a single bandpass table."""
     
-    bandpass, flags = calculate_bandpass(
+    bandpass, flags = calculate_bandpass_from_all_tables(
         msname, table_prefix, delay_bandpass_table_prefix, filter_phase)
 
     if not os.path.exists(f"{table_prefix}_bcal"):

--- a/dsacalib/calibrator_observation.py
+++ b/dsacalib/calibrator_observation.py
@@ -116,7 +116,7 @@ class CalibratorObservation:
 
     def bandpass_calibration(self, delay_bandpass_cal_prefix: str = "") -> int:
         """Bandpass calibration."""
-                if not delay_bandpass_cal_prefix:
+        if not delay_bandpass_cal_prefix:
             delay_bandpass_cal_prefix = self.table_prefix
 
         caltables = [
@@ -134,8 +134,8 @@ class CalibratorObservation:
                     "table": f"{self.table_prefix}_gpcal",
                     "type": "G",
                     "spwmap": [-1]}]
-        error = dc.gain_calibration(
-            self.msname, self.cal.name, self.config['refants'][0], caltables, tbeam=tbeam)
+        error = dc.bandpass_calibration(
+            self.msname, self.cal.name, self.config['refants'][0], caltables)
         return error
 
     def quick_delay_calibration(self) -> int:

--- a/dsacalib/calibrator_observation.py
+++ b/dsacalib/calibrator_observation.py
@@ -38,9 +38,7 @@ class CalibratorObservation:
         """Remove existing calibration tables."""
         tables_to_remove = [
             f"{self.table_prefix}_{ext}" for ext in [
-                "2kcal", "kcal", "bkcal", "gacal", "gpcal", "bcal",]]
-        if self.config["forsystemhealth"]:
-            tables_to_remove += [f"{self.table_prefix}_2gcal"]
+                "2kcal", "kcal", "bkcal", "gacal", "gpcal", "bcal", "2gcal"]]
 
         for path in tables_to_remove:
             if os.path.exists(path):
@@ -86,8 +84,7 @@ class CalibratorObservation:
         for ext in ["kcal", "2kcal"]:
             shutil.rmtree(f"{self.table_prefix}_{ext}")
         error += dc.delay_calibration(
-            self.msname, self.cal.name, refants=self.config["refants"],
-            t2=t2 if self.config["forsystemhealth"] else None)
+            self.msname, self.cal.name, refants=self.config["refants"], t2=t2)
         _check_path(f"{self.table_prefix}_kcal")
 
         return error
@@ -99,13 +96,9 @@ class CalibratorObservation:
             self.cal.name,
             self.config['refants'][0],
             blbased=False,
-            forsystemhealth=self.config["forsystemhealth"],
-            keepdelays=self.config["keepdelays"],
-            #interp_thresh=1.5,
-            #interp_polyorder=7,
             tbeam=tbeam)
         print(error)
-        dc.combine_bandpass_and_delay(self.table_prefix, self.config["forsystemhealth"])
+        dc.combine_bandpass_and_delay(self.table_prefix)
 
         return error
 
@@ -123,14 +116,9 @@ def get_configuration() -> dict:
 
     config = {
         "refants": cal_params["refant"],
-
         "bad_antennas" : [],
         "bad_uvrange" : "2~50m",
         "manual_flags": [],
-
-        "forsystemhealth": False,
-        "keepdelays": False,
-
         "reuse_flags": False}
 
     return config

--- a/dsacalib/calibrator_observation.py
+++ b/dsacalib/calibrator_observation.py
@@ -97,12 +97,10 @@ class CalibratorObservation:
             self.config['refants'][0],
             blbased=False,
             tbeam=tbeam)
-        print(error)
-        dc.combine_bandpass_and_delay(self.table_prefix)
-
         return error
 
     def quick_delay_calibration(self) -> int:
+        """Calibrate delays after averaging entire observation."""
         error = 0
         error += dc.delay_calibration(
             self.msname, self.cal.name, refants=self.config["refants"])

--- a/dsacalib/calibrator_observation.py
+++ b/dsacalib/calibrator_observation.py
@@ -38,7 +38,7 @@ class CalibratorObservation:
         """Remove existing calibration tables."""
         tables_to_remove = [
             f"{self.table_prefix}_{ext}" for ext in [
-                "2kcal", "kcal", "bkcal", "gacal", "gpcal", "bcal", "2gcal"]]
+                "2kcal", "kcal", "gacal", "gpcal", "bcal", "2gcal"]]
 
         for path in tables_to_remove:
             if os.path.exists(path):

--- a/dsacalib/calibrator_observation.py
+++ b/dsacalib/calibrator_observation.py
@@ -89,14 +89,53 @@ class CalibratorObservation:
 
         return error
 
-    def bandpass_and_gain_cal(self, tbeam: str = "60s") -> int:
-        """Gain and bandpass calibration."""
+    def gain_calibration(self, delay_bandpass_cal_prefix: str = "", tbeam: str = "60s") -> int:
+        """Gain calibration."""
+        if not delay_bandpass_cal_prefix:
+            delay_bandpass_cal_prefix = self.table_prefix
+
+        caltables = [
+            {
+                "table": f"{delay_bandpass_cal_prefix}_kcal",
+                "type": "K",
+                "spwmap": [-1]}]
+        if os.path.exists(f"{delay_bandpass_cal_prefix}_bacal"):
+            caltables += [
+                {
+                    "table": f"{delay_bandpass_cal_prefix}_bacal",
+                    "type": "B",
+                    "spwmap": [-1]
+                },
+                {
+                    "table": f"{delay_bandpass_cal_prefix}_bpcal",
+                    "type": "B",
+                    "spwmap": [-1]}]
         error = dc.gain_calibration(
-            self.msname,
-            self.cal.name,
-            self.config['refants'][0],
-            blbased=False,
-            tbeam=tbeam)
+            self.msname, self.cal.name, self.config['refants'][0], caltables, tbeam=tbeam)
+        return error
+
+    def bandpass_calibration(self, delay_bandpass_cal_prefix: str = "") -> int:
+        """Bandpass calibration."""
+                if not delay_bandpass_cal_prefix:
+            delay_bandpass_cal_prefix = self.table_prefix
+
+        caltables = [
+            {
+                "table": f"{delay_bandpass_cal_prefix}_kcal",
+                "type": "K",
+                "spwmap": [-1]}]
+        if os.path.exists(f"{self.table_prefix}_gacal"):
+            caltables += [
+                {
+                    "table": f"{self.table_prefix}_gacal",
+                    "type": "G",
+                    "spwmap": [-1]},
+                {
+                    "table": f"{self.table_prefix}_gpcal",
+                    "type": "G",
+                    "spwmap": [-1]}]
+        error = dc.gain_calibration(
+            self.msname, self.cal.name, self.config['refants'][0], caltables, tbeam=tbeam)
         return error
 
     def quick_delay_calibration(self) -> int:

--- a/dsacalib/ms_io.py
+++ b/dsacalib/ms_io.py
@@ -1016,7 +1016,7 @@ def caltable_to_etcd(msname, calname, caltime, status, pols=None, logger=None):
 def get_antenna_gains(
         gains: np.ndarray, ant1: np.ndarray, ant2: np.ndarray, antennas: List[str], refant=0
 ) -> np.ndarray:
-    """Calculates antenna gains, g_i, from CASA table of G_ij=g_i g_j* for `antennas`.
+    """Calculates antenna gains, g_i, from CASA table of G_ij=1/(g_i g_j*) for `antennas`.
 
     Currently does not support baseline-based gains.
     Refant only used for baseline-based case.

--- a/dsacalib/ms_io.py
+++ b/dsacalib/ms_io.py
@@ -13,6 +13,7 @@ import glob
 import os
 import shutil
 import traceback
+from typing import List
 
 import astropy.units as u
 from astropy.time import Time
@@ -1012,8 +1013,10 @@ def caltable_to_etcd(msname, calname, caltime, status, pols=None, logger=None):
         de.put_dict(f"/mon/cal/{antnum + 1}", dd)
 
 
-def get_antenna_gains(gains, ant1, ant2, refant=0):
-    """Calculates antenna gains, g_i, from CASA table of G_ij=g_i g_j*.
+def get_antenna_gains(
+        gains: np.ndarray, ant1: np.ndarray, ant2: np.ndarray, antennas: List[str], refant=0
+) -> np.ndarray:
+    """Calculates antenna gains, g_i, from CASA table of G_ij=g_i g_j* for `antennas`.
 
     Currently does not support baseline-based gains.
     Refant only used for baseline-based case.
@@ -1024,7 +1027,10 @@ def get_antenna_gains(gains, ant1, ant2, refant=0):
         The gains read in from the CASA gain table. 0th axis is baseline or
         antenna.
     ant1, ant2 : ndarray
-        The antenna pair for each entry along the 0th axis in gains.
+        The antenna pair for each entry along the 0th axis in gains.  Antennas are indexed starting
+        at 0.
+    antennas: List[str]
+        The antennas (names, starting at 1) for which to extract gains.
     refant : int
         The reference antenna index to use to get antenna gains from baseline
         gains.
@@ -1036,21 +1042,22 @@ def get_antenna_gains(gains, ant1, ant2, refant=0):
     antenna_gains : ndarray
         Gains for each antenna in `antennas`.
     """
-    antennas = np.unique(np.concatenate((ant1, ant2)))
-    output_shape = list(gains.shape)
-    output_shape[0] = len(antennas)
-    antenna_gains = np.zeros(tuple(output_shape), dtype=gains.dtype)
-
     if np.all(ant2 == ant2[0]):
         # Antenna-based solutions already
-        for i, ant in enumerate(antennas):
-            antenna_gains[i] = 1 / gains[ant1 == ant]
+        ant1 = list(ant1)
+        antenna_gains = 1 / gains
+        antenna_gains = antenna_gains[[ant1.index(int(ant)-1) for ant in antennas], ...]
+        return antenna_gains
 
     else:
         # Baseline-based solutions
-        assert len(antennas) == 3, (
-            "Baseline-based only supported for trio of" "antennas"
-        )
+        output_shape = list(gains.shape)
+        output_shape[0] = len(antennas)
+        antenna_gains = np.zeros(tuple(output_shape), dtype=gains.dtype)
+
+        assert len(np.unique(np.concatenate((ant1, ant2)))) == 3, (
+            "Baseline-based only supported for trio of antennas")
+
         for i, ant in enumerate(antennas):
             ant1idxs = np.where(ant1 == ant)[0]
             ant2idxs = np.where(ant2 == ant)[0]
@@ -1088,7 +1095,7 @@ def get_antenna_gains(gains, ant1, ant2, refant=0):
                 np.sqrt(np.abs(g01 * g20 / g21))
                 * np.exp(sign * 1.0j * np.angle(gains[idx_phase]))
             ) ** (-1)
-    return antennas, antenna_gains
+        return antenna_gains
 
 
 def get_delays(antennas, msname, calname, applied_delays):

--- a/dsacalib/plotting.py
+++ b/dsacalib/plotting.py
@@ -1410,7 +1410,7 @@ def plot_beamformer_weights(
             temp = data[64:].reshape(64, 48, 2, 2)
             gains[i, :, corridx, :, :] = temp[..., 0] + 1.0j * temp[..., 1]
     gains = gains.reshape((len(beamformer_names), len(antennas), len(corrlist) * 48, 2))
-    gains = gains/gains[:, 0, :, :]
+    gains = gains/gains[:, [0], :, :]
     # Phase, polarization B
     fig, ax = plt.subplots(
         nplots * ny, nx, figsize=(6 * nx, 2.5 * ny * nplots), sharex=True, sharey=False

--- a/dsacalib/plotting.py
+++ b/dsacalib/plotting.py
@@ -1410,7 +1410,7 @@ def plot_beamformer_weights(
             temp = data[64:].reshape(64, 48, 2, 2)
             gains[i, :, corridx, :, :] = temp[..., 0] + 1.0j * temp[..., 1]
     gains = gains.reshape((len(beamformer_names), len(antennas), len(corrlist) * 48, 2))
-
+    gains = gains/gains[:, 0, :, :]
     # Phase, polarization B
     fig, ax = plt.subplots(
         nplots * ny, nx, figsize=(6 * nx, 2.5 * ny * nplots), sharex=True, sharey=False

--- a/dsacalib/routines.py
+++ b/dsacalib/routines.py
@@ -147,9 +147,13 @@ def calibrate_measurement_set(
         )
         error = calobs.bandpass_and_gain_cal()
         if error > 0:
-            status = cs.update(status, cs.DELAY_CAL_ERR)
-            message = f"{error} non-fatal errors occured in delay calibration of {msname}."
+            status = cs.update(status, cs.GAIN_BP_CAL_ERR)
+            message = f"{error} non-fatal errors occured in gain calibration of {msname}."
             du.warning_logger(logger, message)
+
+
+        current_erorr = cs.GAIN_BP_CAL_ERR
+        combine_tables(msname, f"{msname}_{calname}")
 
     except Exception as exc:
         status = cs.update(status, current_error)

--- a/dsacalib/routines.py
+++ b/dsacalib/routines.py
@@ -171,7 +171,9 @@ def quick_bfweightcal(msname: str, cal: "CalibratorSource" = None, **kwargs) -> 
     calobs.reset_calibration()
     error = 0
     error += calobs.quick_delay_calibration()
-    error += calobs.bandpass_and_gain_cal()
+    error += calobs.bandpass_calibration()
+    error += calobs.gain_calibration()
+    error += calobs.bandpass_calibration()
     combine_tables(msname, cal.name)
 
     with table(f"{msname}.ms") as tb:
@@ -204,7 +206,9 @@ def quick_calibration(msname: str, cal: "CalibratorSource" = None, **kwargs) -> 
     calobs.reset_calibration()
     error = 0
     error += calobs.quick_delay_calibration()
-    error += calobs.bandpass_and_gain_cal()
+    error += calobs.bandpass_calibration()
+    error += calobs.gain_calibration()
+    error += calobs.bandpass_calibration()
 
     return error
 

--- a/dsacalib/routines.py
+++ b/dsacalib/routines.py
@@ -127,7 +127,7 @@ def calibrate_measurement_set(
             error += calobs.bandpass_calibration()
 
         else:
-            error += calobs.gain_calibration(delay_bandpass_cal_prefix)
+            error = calobs.gain_calibration(delay_bandpass_cal_prefix)
 
         if error > 0:
             status = cs.update(status, cs.GAIN_BP_CAL_ERR)

--- a/dsacalib/utils.py
+++ b/dsacalib/utils.py
@@ -21,7 +21,9 @@ from antpos.utils import get_itrf
 from astropy.coordinates import Angle
 
 from dsacalib import constants as ct
+from dsacalib.preprocess import read_nvss_catalog
 
+NVSS = None
 
 CalibratorSource = namedtuple(
     "CalibratorSource", "name ra dec flux epoch direction pa maj_axis min_axis")
@@ -72,6 +74,18 @@ def generate_calibrator_source(
 
     return CalibratorSource(
         name, ra, dec, flux, epoch, direction, pa, maj_axis, min_axis)
+
+
+def update_nvss():
+    global NVSS
+    NVSS = read_nvss_catalog()
+
+
+def calibrator_source_from_name(name):
+    if NVSS is None:
+         update_nvss()
+    record = NVSS.loc[f"NVSS {name}"]
+    return generate_calibrator_source(name, record["ra"]*u.deg, record["dec"]*u.deg, record["flux_20_cm"]*1e-3)
 
 
 class Direction:

--- a/dsacalib/weights.py
+++ b/dsacalib/weights.py
@@ -15,7 +15,7 @@ from dsautils import cnf
 
 import dsacalib.constants as ct
 from dsacalib.fringestopping import calc_uvw
-from dsacalib.ms_io import get_antenna_gains, get_delays, read_caltable
+from dsacalib.ms_io import get_antenna_gains, get_delays, read_caltable, freq_GHz_from_ms
 
 
 def get_refmjd() -> float:
@@ -484,8 +484,31 @@ def average_beamformer_solutions(
     return written_files, antenna_flags_badsolns
 
 
+def set_freq_beamformer_weights(corr_list: List[int]):
+    """Set the frequency for the beamformer weights."""
+    ncorr = len(corr_list)
+    fweights = np.ones((ncorr, 48), dtype=np.float32)
+
+    conf = cnf.Conf()
+    corr_params = conf.get('corr')
+    nchan = corr_params["nchan"]
+    dfreq = corr_params["bw_GHz"] / nchan
+    if corr_params["chan_ascending"]:
+        fobs = corr_params["f0_GHz"] + np.arange(nchan) * dfreq
+    else:
+        fobs = corr_params["f0_GHz"] - np.arange(nchan) * dfreq
+    nchan_spw = corr_params["nchan_spw"]
+
+    for i, corr_id in enumerate(corr_list):
+        ch0 = corr_params["ch0"][f"corr{corr_id:02d}"]
+        fobs_corr = fobs[ch0:ch0 + nchan_spw]
+        fweights[i, :] = fobs_corr.reshape(fweights.shape[1], -1).mean(axis=1)
+
+    return fweights
+
+
 def write_beamformer_weights(
-    msname, calname, caltime, antennas, corr_list, antenna_flags, tol=0.3
+    msname, calname, caltime, antennas, corr_list, beamformer_dir, antenna_flags, tol=0.3
 ):
     """Writes weights for the beamformer.
 
@@ -513,91 +536,51 @@ def write_beamformer_weights(
 
     Returns
     -------
-    corr_list : list
     bu : array
         The length of the baselines in the u direction for each antenna
         relative to antenna 24.
-    fweights : ndarray
-        The frequencies corresponding to the beamformer weights, dimensions
-        (correlator, frequency).
     filenames : list
         The names of the file containing the beamformer weights.
+    antenna_flags_badsolns : np.ndarray, dimensions(nant, npol)
+        1 where the antenna/pol pair is flagged for having bad beamformer weight solutions
     """
     ncorr = len(corr_list)
-    weights = np.ones((ncorr, len(antennas), 48, 2), dtype=np.complex64)
-    fweights = np.ones((ncorr, 48), dtype=np.float32)
+    nant = len(antennas)
+    npol = 2
+    nfreq = 48
 
-    config = get_config()
-    beamformer_dir = config["beamformer_dir"]
-
-    conf = cnf.Conf()
-    corr_params = conf.get('corr')
-    nchan = corr_params["nchan"]
-    dfreq = corr_params["bw_GHz"] / nchan
-    if corr_params["chan_ascending"]:
-        fobs = corr_params["f0_GHz"] + np.arange(nchan) * dfreq
-    else:
-        fobs = corr_params["f0_GHz"] - np.arange(nchan) * dfreq
-    nchan_spw = corr_params["nchan_spw"]
-    for i, corr_id in enumerate(corr_list):
-        ch0 = corr_params["ch0"][f"corr{corr_id:02d}"]
-        fobs_corr = fobs[ch0 : ch0 + nchan_spw]
-        fweights[i, :] = fobs_corr.reshape(fweights.shape[1], -1).mean(axis=1)
-
+    fweights = set_freq_beamformer_weights(corr_list)
     bu = calc_eastings(antennas)
 
-    with table(f"{msname}.ms/SPECTRAL_WINDOW") as tb:
-        fobs = np.array(tb.CHAN_FREQ[:]) / 1e9
+    fobs = freq_GHz_from_ms(msname)
     fobs = fobs.reshape(fweights.size, -1).mean(axis=1)
-    f_reversed = not np.all(np.abs(fobs - fweights.ravel()) / fweights.ravel() < 1e-5)
+    f_reversed = not np.allclose(fobs, fweights.ravel())
     if f_reversed:
-        assert np.all(np.abs(fobs[::-1] - fweights.ravel()) / fweights.ravel() < 1e-5)
+        assert np.allclose(fobs[::-1], fweights.ravel())
 
-    gains, _time, flags, ant1, ant2 = read_caltable(f"{msname}_{calname}_gacal", True)
+    gains, _time, flags, ant1, ant2 = read_caltable(f"{msname}_{calname}_bcal", cparam=True)
     gains[flags] = np.nan
-    gains = np.nanmean(gains, axis=1)
-    phases, _, flags, ant1p, ant2p = read_caltable(f"{msname}_{calname}_gpcal", True)
-    phases[flags] = np.nan
-    phases = np.nanmean(phases, axis=1)
-    assert np.all(ant1p == ant1)
-    assert np.all(ant2p == ant2)
-    gantenna, gains = get_antenna_gains(gains * phases, ant1, ant2)
+    gantennas, gains = get_antenna_gains(gains, ant1, ant2)
 
-    bgains, _, flags, ant1, ant2 = read_caltable(f"{msname}_{calname}_bcal", True)
-    bgains[flags] = np.nan
-    bgains = np.nanmean(bgains, axis=1)
-    bantenna, bgains = get_antenna_gains(bgains, ant1, ant2)
-    assert np.all(bantenna == gantenna)
+    assert gains.shape[0] == nant
+    assert gains.shape[-1] == npol
 
-    nantenna = gains.shape[0]
-    npol = gains.shape[-1]
-
-    gains = gains * bgains
-    print(gains.shape)
-    gains = gains.reshape((nantenna, -1, npol))
     if f_reversed:
-        gains = gains[:, ::-1, :]
-    gains = gains.reshape(nantenna, ncorr, -1, npol)
-    nfint = gains.shape[2] // weights.shape[2]
-    assert gains.shape[2] % weights.shape[2] == 0
+        gains = gains.reshape((nant, -1, npol))[:, ::-1, :]
+    gains = gains.reshape(nant, ncorr, -1, npol)
+    assert gains.shape[2] % nfreq == 0
 
-    gains = np.nanmean(
-        gains.reshape(gains.shape[0], gains.shape[1], -1, nfint, gains.shape[3]), axis=3
-    )
-    if not np.all(ant2 == ant2[0]):
-        idxs = np.where(ant1 == ant2)
-        gains = gains[idxs]
-        ant1 = ant1[idxs]
-    for i, antid in enumerate(ant1):
+    gains = np.nanmean(gains.reshape(ncorr, nant, nfreq, -1, npol), axis=3)
+
+    weights = np.ones((ncorr, nant, nfreq, npol), dtype=np.complex64)
+    for i, antid in enumerate(gantennas):
         if antid + 1 in antennas:
             idx = np.where(antennas == antid + 1)[0][0]
             weights[:, idx, ...] = gains[i, ...]
 
-    fracflagged = np.sum(np.sum(np.isnan(weights), axis=2), axis=0) / (
-        weights.shape[0] * weights.shape[2]
-    )
+    fracflagged = (
+        np.sum(np.sum(np.isnan(weights), axis=2), axis=0) / (weights.shape[0] * weights.shape[2]))
     antenna_flags_badsolns = fracflagged > tol
-    weights[np.isnan(weights)] = 0.0
 
     # Divide by the first non-flagged antenna
     idx0, idx1 = np.nonzero(np.logical_not(antenna_flags + antenna_flags_badsolns))
@@ -616,7 +599,8 @@ def write_beamformer_weights(
         with open(f"{beamformer_dir}/{fname}.dat", "wb") as f:
             f.write(bytes(wcorr))
         filenames += [f"{fname}.dat".format(fname)]
-    return corr_list, bu, fweights, filenames, antenna_flags_badsolns
+
+    return bu, filenames, antenna_flags_badsolns
 
 
 def write_beamformer_solutions(
@@ -625,7 +609,6 @@ def write_beamformer_solutions(
     caltime,
     antennas,
     applied_delays,
-    corr_list=np.arange(1, 17),
     flagged_antennas=None,
     pols=None,
 ):
@@ -666,12 +649,13 @@ def write_beamformer_solutions(
     """
     config = get_config()
     beamformer_dir = config.beamformer_dir
+    pols = config.pols
+    corr_list = config.corr_list
 
-    if pols is None:
-        pols = ["B", "A"]
+    # Set the delays and flags for large delays
     beamformer_flags = {}
     delays, flags = get_delays(antennas, msname, calname, applied_delays)
-    print("delay flags:", flags.shape)
+
     if flagged_antennas is not None:
         for item in flagged_antennas:
             ant, pol = item.split(" ")
@@ -694,13 +678,9 @@ def write_beamformer_solutions(
     #    delays = delays-np.min(delays[~flags])
 
     caltime.precision = 0
-    (
-        corr_list,
-        eastings,
-        _fobs,
-        weights_files,
-        flags_badsolns,
-    ) = write_beamformer_weights(msname, calname, caltime, antennas, corr_list, flags)
+    eastings, weights_files, flags_badsolns = write_beamformer_weights(
+        msname, calname, caltime, antennas, corr_list, beamformer_dir, flags)
+
     idxant, idxpol = np.nonzero(flags_badsolns)
     for i, ant in enumerate(idxant):
         key = f"{antennas[ant]} {pols[idxpol[i]]}"
@@ -731,4 +711,5 @@ def write_beamformer_solutions(
             encoding="utf-8"
     ) as file:
         yaml.dump(calibration_dictionary, file)
+
     return flags

--- a/dsacalib/weights.py
+++ b/dsacalib/weights.py
@@ -572,15 +572,11 @@ def write_beamformer_weights(
 
     gains = np.nanmean(gains.reshape(nant, ncorr, nfreq, -1, npol), axis=3)
     weights = gains.swapaxes(0, 1).astype(np.complex64).copy()
+    weights[np.isnan(weights)] = 0.0
 
     fracflagged = (
         np.sum(np.sum(np.isnan(weights), axis=2), axis=0) / (weights.shape[0] * weights.shape[2]))
     antenna_flags_badsolns = fracflagged > tol
-
-    # Divide by the first non-flagged antenna
-    idx0, idx1 = np.nonzero(np.logical_not(antenna_flags + antenna_flags_badsolns))
-    weights = weights / weights[:, idx0[0], ..., idx1[0]][:, np.newaxis, :, np.newaxis]
-    weights[np.isnan(weights)] = 0.0
 
     filenames = []
     for i, corr_idx in enumerate(corr_list):

--- a/dsacalib/weights.py
+++ b/dsacalib/weights.py
@@ -566,17 +566,18 @@ def write_beamformer_weights(
     assert gains.shape[-1] == npol
 
     if f_reversed:
+        print("Frequencies are reversed. Changing order of weights.")
         gains = gains.reshape((nant, -1, npol))[:, ::-1, :]
     gains = gains.reshape(nant, ncorr, -1, npol)
     assert gains.shape[2] % nfreq == 0
 
     gains = np.nanmean(gains.reshape(nant, ncorr, nfreq, -1, npol), axis=3)
     weights = gains.swapaxes(0, 1).astype(np.complex64).copy()
-    weights[np.isnan(weights)] = 0.0
 
     fracflagged = (
         np.sum(np.sum(np.isnan(weights), axis=2), axis=0) / (weights.shape[0] * weights.shape[2]))
     antenna_flags_badsolns = fracflagged > tol
+    weights[np.isnan(weights)] = 0.0
 
     filenames = []
     for i, corr_idx in enumerate(corr_list):

--- a/dsacalib/weights.py
+++ b/dsacalib/weights.py
@@ -1,8 +1,10 @@
 """Determine and inspect beamformer weights."""
 
+from typing import List
 import glob
 import os
 from collections import namedtuple
+from datetime import datetime, timedelta, timezone
 
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -10,7 +12,6 @@ import numpy as np
 import yaml
 from antpos.utils import get_itrf
 import scipy  #pylint: disable=unused-import # must come before casacore
-from casacore.tables import table
 from dsautils import cnf
 
 import dsacalib.constants as ct
@@ -19,6 +20,7 @@ from dsacalib.ms_io import get_antenna_gains, get_delays, read_caltable, freq_GH
 
 
 def get_refmjd() -> float:
+    """Get the reference mjd used in fringestopping."""
     conf = cnf.Conf()
     return conf.get("fringe")["refmjd"]
 
@@ -57,7 +59,6 @@ def get_good_solution(
     """Find good set of solutions and calculate average gains.
     TODO: go from good bfnames to average gains.
     """
-    from datetime import datetime, timedelta, timezone
 
     config = get_config()
 
@@ -355,7 +356,7 @@ def sort_beamformer_names(beamformer_names):
 def filter_beamformer_solutions(beamformer_names, start_time):
     """Removes beamformer solutions inconsistent with the latest solution."""
     config = get_config()
-    beamformer_dir = config["beamformer_dir"]
+    beamformer_dir = config.beamformer_dir
 
     if len(beamformer_names) == 0:
         return beamformer_names, None

--- a/services/calibration_service.py
+++ b/services/calibration_service.py
@@ -113,6 +113,7 @@ def calibrate_file(calname, flist):
     status = calibrate_measurement_set(
         msname,
         filenames[date][calname]["cal"],
+        delay_bandpass_cal_prefix=delay_bandpass_cal_prefix,
         logger=LOGGER,
         throw_exceptions=False,
     )

--- a/services/calibration_service.py
+++ b/services/calibration_service.py
@@ -115,9 +115,8 @@ def calibrate_file(calname, flist):
         filenames[date][calname]["cal"],
         logger=LOGGER,
         throw_exceptions=False,
-        forsystemhealth=True,
     )
-
+    
     # Write solutions to etcd
     caltable_to_etcd(
         msname,
@@ -151,17 +150,6 @@ def calibrate_file(calname, flist):
             exc,
             throw=False)
 
-    status = calibrate_measurement_set(
-        msname,
-        filenames[date][calname]["cal"],
-        logger=LOGGER,
-        throw_exceptions=False,
-        keepdelays=False,
-        forsystemhealth=False,
-        reuse_flags=True)
-    LOGGER.info(
-        f"Calibrated {msname}.ms for beamformer weights with status {status}")
-
     try:
         applied_delays = extract_applied_delays(first_true(flist), config["antennas"])
         # Write beamformer solutions for one source
@@ -179,9 +167,6 @@ def calibrate_file(calname, flist):
             f"calculation of beamformer weights for {msname}.ms",
             exc,
             throw=False)
-
-    # Create the bandpass phase table for plotting later
-    calibrate_phase_single_ms(msname, config["refant"], calname)
 
     beamformer_solns, beamformer_names = generate_averaged_beamformer_solns(
         config["snap_start_time"], caltime, config["beamformer_dir"], config["corr_list"],


### PR DESCRIPTION
1. Don't normalize them (but normalize in plotting)
2. Use savgol filter instead of a median filter to smooth the phase portion of the bandpass
3. One-pass calibration, then creation of an overall bcal table from which the beamformer weights can be generated
4. A delay and bandpass prefix can be passed to calibration, so that only gain calibration is done.  However beamformer weights are currently not being generated without error in this case.